### PR TITLE
fixed full postgress yaml file, updated case file, removed operator bundle, added TO DOs

### DIFF
--- a/docs/2-Prepare/Stage/Images.mdx
+++ b/docs/2-Prepare/Stage/Images.mdx
@@ -56,7 +56,6 @@ Image tag formats:
 |navigator|cp.icr.io/cp/cp4a/ban/navigator|ga-30x-icn|3.0.15.0 (x = 15)|
 |navigator-sso|cp.icr.io/cp/cp4a/ban/navigator-sso|ga-30x-icn|3.0.15.0 (x = 15)|
 |taskmgr|cp.icr.io/cp/cp4a/fncm/taskmgr|ga-30x-tm|3.0.15.0 (x = 15)|
-|operator-bundle|icr.io/cpopen/ibm-fncm-operator-bundle|55.xx.x|5.5.12.0 (xx.x = 12.0)|
 |operator-container|icr.io/cpopen/ibm-fncm-operator-container|icp4a-content-operator:xx.0.x|23.0.2 (xx x = 23 2)|
 |ier|cp.icr.io/cp/cp4a/ier/ier|ga-52xx-IF005-ier-2302|5.2.1.8 IF005 (xx= 18)|
 
@@ -73,7 +72,6 @@ docker pull cp.icr.io/cp/cp4a/fncm/graphql:ga-5512-p8cgql
 docker pull cp.icr.io/cp/cp4a/ban/navigator:ga-3015-icn
 docker pull cp.icr.io/cp/cp4a/ban/navigator-sso:ga-3015-icn
 docker pull cp.icr.io/cp/cp4a/fncm/taskmgr:ga-3015-tm
-docker pull icr.io/cpopen/ibm-fncm-operator-bundle:55.12.0
 docker pull icr.io/cpopen/icp4a-content-operator:23.0.2
 ```
 
@@ -111,7 +109,6 @@ docker tag cp.icr.io/cp/cp4a/ban/navigator-sso:ga-3015-icn $LOCAL_REGISTRY/cp/cp
 docker tag cp.icr.io/cp/cp4a/ban/navigator-sso:ga-3015-icn-amd64 $LOCAL_REGISTRY/cp/cp4a/ban/navigator-sso:ga-3015-icn-amd64
 docker tag cp.icr.io/cp/cp4a/fncm/taskmgr:ga-3015-tm $LOCAL_REGISTRY/cp/cp4a/fncm/taskmgr:ga-3015-tm
 docker tag cp.icr.io/cp/cp4a/fncm/taskmgr:ga-3015-tm-amd64 $LOCAL_REGISTRY/cp/cp4a/fncm/taskmgr:ga-3015-tm-amd64
-docker tag icr.io/cpopen/ibm-fncm-operator-bundle:55.12.0 $LOCAL_REGISTRY/cpopen/ibm-fncm-operator-bundle:55.12.0
 docker tag icr.io/cpopen/icp4a-content-operator:23.0.2 $LOCAL_REGISTRY/cpopen/icp4a-content-operator:23.0.2
 docker tag icr.io/cpopen/icp4a-content-operator:23.0.2 $LOCAL_REGISTRY/cpopen/icp4a-content-operator:23.0.2-amd64
 ```
@@ -144,7 +141,6 @@ docker push $LOCAL_REGISTRY/cp/cp4a/fncm/taskmgr:ga-3015-tm
 docker push $LOCAL_REGISTRY/cp/cp4a/fncm/taskmgr:ga-3015-tm-amd64
 docker push $LOCAL_REGISTRY/cpopen/icp4a-content-operator:23.0.2
 docker push $LOCAL_REGISTRY/cpopen/icp4a-content-operator:23.0.2-amd64
-docker push $LOCAL_REGISTRY/cpopen/ibm-fncm-operator-bundle:55.12.0
 ```
 
 If including IER

--- a/docs/3-Create/Deploy/operator.mdx
+++ b/docs/3-Create/Deploy/operator.mdx
@@ -5,16 +5,16 @@ title: FNCM Operator
 ---
 ## Deploy Operator
 
-Download the IBM Case file for FileNet Content Manager. As of this writing it is **v1.7.1**. You can check for newer versions by going [here](https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-fncm-case)
+Download the IBM Case file for FileNet Content Manager. As of this writing it is **v1.8.0**. You can check for newer versions by going [here](https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-fncm-case)
 
 ```
-wget https://github.com/IBM/cloud-pak/raw/master/repo/case/ibm-cp-fncm-case/1.7.1/ibm-cp-fncm-case-1.7.1.tgz
+wget https://github.com/IBM/cloud-pak/raw/master/repo/case/ibm-cp-fncm-case/1.8.0/ibm-cp-fncm-case-1.8.0.tgz
 ```
 
 Extract the case file
 
 ```
-tar zxvf ibm-cp-fncm-case-1.7.1.tgz
+tar zxvf ibm-cp-fncm-case-1.8.0.tgz
 ```
 
 Change into the operator directory and extract the container samples file
@@ -22,7 +22,8 @@ Change into the operator directory and extract the container samples file
 ```tsx
 cd ibm-cp-fncm-case/inventory/fncmOperator/files/deploy/crs/
 
-tar xvf container-samples-5.5.11.tar
+// this name is equivalent to the corresponding filenet version and thus may change
+tar xvf container-samples-5.5.12.tar
 ```
 
 ### Scripted Operator deployment
@@ -160,6 +161,8 @@ kubectl apply -f ldap_secrets.yaml
 ```
 
 ## Deploying CR
+
+{/* TO DO : UPDATE ALL BELOW TO LATEST VERSION*/}
 
 :::note
 A full version of the CR for release 5.5.11 can be found here. It contains a lot of extra settings that are covered in the Appendix below.
@@ -840,18 +843,18 @@ spec:
 
 ### Upgrading FNCM in the cluster
 
-This assumes you are running a version older than v1.7.1.
+This assumes you are running a version older than v1.8.0.
 
-Download the most recent IBM Case file for FileNet Content Manager. As of this writing it is v1.7.1. You can check for newer versions by going [here](https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-fncm-case)
+Download the most recent IBM Case file for FileNet Content Manager. As of this writing it is v1.8.0. You can check for newer versions by going [here](https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-fncm-case)
 
 ```
-wget https://github.com/IBM/cloud-pak/raw/master/repo/case/ibm-cp-fncm-case/1.7.1/ibm-cp-fncm-case-1.7.1.tgz
+wget https://github.com/IBM/cloud-pak/raw/master/repo/case/ibm-cp-fncm-case/1.8.0/ibm-cp-fncm-case-1.8.0.tgz
 ```
 
 Extract the case file
 
 ```
-tar zxvf ibm-cp-fncm-case-1.7.1.tgz
+tar zxvf ibm-cp-fncm-case-1.8.0.tgz
 ```
 
 Change into the operator directory and extract the container samples file
@@ -859,7 +862,8 @@ Change into the operator directory and extract the container samples file
 ```tsx
 cd ibm-cp-fncm-case/inventory/fncmOperator/files/deploy/crs/
 
-tar xvf container-samples-5.5.11.tar
+// this name is equivalent to the corresponding filenet version and thus may change
+tar xvf container-samples-5.5.12.tar
 ```
 
 #### Upgrading the operator manually
@@ -867,7 +871,7 @@ tar xvf container-samples-5.5.11.tar
 :::info
 It's important to note that if you are running airgapped and you have already staged the operator image to your repository, you will need to update the image path in the `operator.yaml` file. The below example uses `sed` and updates every `image:` entry.
 ```
-sed -i "s/image:.*/image: \"<REPO URL>\/path\/to\/icp4a-content-operator:23.0.1-IF003\"/" operator.yaml
+sed -i "s/image:.*/image: \"<REPO URL>\/path\/to\/icp4a-content-operator:23.0.2\"/" operator.yaml
 ```
 This needs to be done **before** applying the `operator.yaml`! 
 

--- a/docs/3-Create/Deploy/operator.mdx
+++ b/docs/3-Create/Deploy/operator.mdx
@@ -162,7 +162,7 @@ kubectl apply -f ldap_secrets.yaml
 
 ## Deploying CR
 
-{/* TO DO : UPDATE ALL BELOW TO LATEST VERSION*/}
+{/* TO DO : DOUBLE CHECK BELOW AND UPDATE FULL CR VERSION TO LATEST VERSION*/}
 
 :::note
 A full version of the CR for release 5.5.11 can be found here. It contains a lot of extra settings that are covered in the Appendix below.
@@ -186,9 +186,9 @@ metadata:
     app.kubernetes.io/instance: ibm-fncm
     app.kubernetes.io/managed-by: ibm-fncm
     app.kubernetes.io/name: ibm-fncm
-    release: 5.5.10
+    release: 5.5.12
 spec:
-  appVersion: 22.0.2
+  appVersion: 23.0.2
   var_setlog_true: false
   var_navigator_no_log: false
   var_fncm_no_log: false
@@ -349,7 +349,7 @@ spec:
       image:
         ## The default repository is the IBM Entitled Registry.
         repository: cp.icr.io/cp/cp4a/fncm/cpe
-        tag: ga-5510-p8cpe-if001
+        tag: ga-5512-p8cpe
         pull_policy: IfNotPresent
       log:
        format: json
@@ -426,7 +426,7 @@ spec:
       image:
         ## The default repository is the IBM Entitled Registry.
         repository: cp.icr.io/cp/cp4a/fncm/css
-        tag: ga-5510-p8css-if001
+        tag: ga-5512-p8css
         pull_policy: IfNotPresent
       log:
         format: json
@@ -491,7 +491,7 @@ spec:
       image:
         ## The default repository is the IBM Entitled Registry.
         repository: cp.icr.io/cp/cp4a/fncm/cmis
-        tag: ga-307-cmis-la103
+        tag: ga-307-cmis-if004
         pull_policy: IfNotPresent
       log:
         format: json
@@ -565,7 +565,7 @@ spec:
       image:
         ## The default repository is the IBM Entitled Registry.
         repository: cp.icr.io/cp/cp4a/fncm/graphql
-        tag: ga-5510-p8cgql-if001
+        tag: ga-5512-p8cgql
         pull_policy: IfNotPresent
       log:
         format: json
@@ -626,7 +626,7 @@ spec:
       image:
         ## The default repository is the IBM Entitled Registry.
         repository: cp.icr.io/cp/cp4a/fncm/extshare
-        tag: ga-3013-es-la102
+        tag: ga-3015-es
         pull_policy: IfNotPresent
       resources:
         requests:
@@ -685,7 +685,7 @@ spec:
       image:
         ## The default repository is the IBM Entitled Registry.
         repository: cp.icr.io/cp/cp4a/fncm/taskmgr
-        tag: ga-3013-tm-la102
+        tag: ga-3015-tm
         pull_policy: IfNotPresent
       resources:
         requests:
@@ -756,7 +756,7 @@ spec:
     image:
       ## The default repository is the IBM Entitled Registry
       repository: cp.icr.io/cp/cp4a/ban/navigator
-      tag: ga-3013-icn-la102
+      tag: ga-3015-icn
       pull_policy: IfNotPresent
     log:
       format: json

--- a/static/deployment_files/Postgres/postgres.yaml
+++ b/static/deployment_files/Postgres/postgres.yaml
@@ -23,7 +23,7 @@ spec:
   resources:
     requests:
       storage: 50Gi
-  storageClassName: efs-sc
+  storageClassName: ebs-gp3-sc
   volumeMode: Filesystem
 ---
 kind: PersistentVolumeClaim
@@ -38,7 +38,7 @@ spec:
   resources:
     requests:
       storage: 5Gi
-  storageClassName: efs-sc
+  storageClassName: ebs-gp3-sc
   volumeMode: Filesystem
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Changed efs-sc to ebs-gp3-sc in the full (combined) postgress yaml file. Updated case file from 1.7.1 to 1.8.0 and changed the relevant commands. Removed operator bundle from images, as it does not work and is not needed. Updated sample yaml in operator page, and added TO DO in comments to finish updating full CR.